### PR TITLE
Enhance honeypot protections on contact form

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+  extends: [
+    "@remix-run/eslint-config",
+    "@remix-run/eslint-config/node",
+  ],
+};

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -15,13 +15,14 @@ export function Footer() {
       { threshold: 0.1 }
     );
 
-    if (footerRef.current) {
-      observer.observe(footerRef.current);
+    const node = footerRef.current;
+    if (node) {
+      observer.observe(node);
     }
 
     return () => {
-      if (footerRef.current) {
-        observer.unobserve(footerRef.current);
+      if (node) {
+        observer.unobserve(node);
       }
     };
   }, [controls]);

--- a/app/components/ui/animated-shiny-text.tsx
+++ b/app/components/ui/animated-shiny-text.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, FC, ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { cn } from "~/lib/utils";
 
@@ -8,11 +8,11 @@ interface AnimatedShinyTextProps {
   shimmerWidth?: number;
 }
 
-export const AnimatedShinyText: FC<AnimatedShinyTextProps> = ({
+export function AnimatedShinyText({
   children,
   className,
   shimmerWidth = 100,
-}) => {
+}: AnimatedShinyTextProps) {
   return (
     <p
       style={
@@ -35,6 +35,6 @@ export const AnimatedShinyText: FC<AnimatedShinyTextProps> = ({
       {children}
     </p>
   );
-};
+}
 
 export default AnimatedShinyText;

--- a/app/components/ui/text-reveal.tsx
+++ b/app/components/ui/text-reveal.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { motion, MotionValue, useScroll, useTransform } from "framer-motion";
-import { FC, ReactNode, useRef } from "react";
+import { motion, useScroll, useTransform } from "framer-motion";
+import type { MotionValue } from "framer-motion";
+import { useRef } from "react";
+import type { ReactNode } from "react";
 import { useIsMobile } from "~/hooks/useIsMobile";
 
 import { cn } from "~/lib/utils";
@@ -11,10 +13,7 @@ interface TextRevealByWordProps {
   className?: string;
 }
 
-export const TextRevealByWord: FC<TextRevealByWordProps> = ({
-  text,
-  className,
-}) => {
+export function TextRevealByWord({ text, className }: TextRevealByWordProps) {
   const isMobile = useIsMobile();
   const targetRef = useRef<HTMLDivElement | null>(null);
 
@@ -114,7 +113,7 @@ export const TextRevealByWord: FC<TextRevealByWordProps> = ({
       </div>
     </div>
   );
-};
+}
 
 interface WordProps {
   children: ReactNode;
@@ -123,7 +122,7 @@ interface WordProps {
   isBold?: boolean;
 }
 
-const Word: FC<WordProps> = ({ children, progress, range, isBold = false }) => {
+function Word({ children, progress, range, isBold = false }: WordProps) {
   const opacity = useTransform(progress, range, [0, 1]);
   return (
     <span className="xl:lg-3 relative mx-0.5 lg:mx-1">
@@ -144,6 +143,6 @@ const Word: FC<WordProps> = ({ children, progress, range, isBold = false }) => {
       </motion.span>
     </span>
   );
-};
+}
 
 export default TextRevealByWord;

--- a/app/lib/blog.local.server.ts
+++ b/app/lib/blog.local.server.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { processMarkdown } from "./md.server";
-import { authors, Metadata } from "./types";
+import { authors } from "./types";
+import type { Metadata } from "./types";
 
 function parseFrontmatter(fileContent: string) {
   const frontmatterRegex = /---\s*([\s\S]*?)\s*---/;

--- a/app/lib/blog.server.ts
+++ b/app/lib/blog.server.ts
@@ -1,5 +1,5 @@
 import { LRUCache } from "lru-cache";
-import { BlogPost } from "./types";
+import type { BlogPost } from "./types";
 
 const postsCache = new LRUCache<string, BlogPost>({
   max: 1000,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -12,18 +12,20 @@ import {
 import { Analytics } from "@vercel/analytics/remix";
 import type { LoaderFunctionArgs, MetaFunction } from "@vercel/remix";
 import { json } from "@vercel/remix";
-import { forwardRef, ReactNode, useEffect, useRef, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import Tailwind from "~/styles/tailwind.css?url";
+import VisuallyHidden from "~/styles/visually-hidden.css?url";
 import { Footer } from "./components/footer";
 import { Logo } from "./components/logo";
 import { cn } from "./lib/utils";
-import { Button } from "./components/ui/button";
 
 export const config = { runtime: "edge" };
 
 export function links() {
   return [
     { rel: "stylesheet", href: Tailwind },
+    { rel: "stylesheet", href: VisuallyHidden },
   ];
 }
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -10,7 +10,6 @@ export default function Route() {
   return (
     <>
       <Hero />
-      {/* <Features /> */}
       <Plan />
       <Demo />
       <Mission />
@@ -38,62 +37,6 @@ function Hero() {
           <h2 className="xs:text-[26px] lg:text-[28px] xl:text-[30px] standard-type-body text-muted-foreground text-wrap-pretty">
             The orchestration layer for high-mix production lines in critical industries
           </h2>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-const features = [
-  {
-    title: "Digitized Expertise",
-    icon: "/icons/cube.svg",
-    description:
-      "We're using our expertise in precision machining to digitize each step of the manufacturing process to build and operate factories where AI and robotics operate at scale.",
-  },
-  {
-    title: "Virtual Factories",
-    icon: "/icons/diamond.svg",
-    description:
-      "We've built a software-controlled virtual factory that allows us to simulate and solve end-to-end operations before starting production.",
-  },
-  {
-    title: "On-Site Deployments",
-    icon: "/icons/triangle.svg",
-    description: "We'll build our first production line in Dallas, TX in Q3.",
-  },
-];
-
-function Features() {
-  return (
-    <div className="section flex flex-col items-center justify-center gap-8 min-h-[100vh] bg-foreground text-muted">
-      <div className="flex flex-col w-full max-w-section mx-auto px-section gap-24 py-24 lg:py-12">
-        <div className="w-full relative">
-          <h2 className="text-base font-medium tracking-tighter top-[-22px] absolute left-0">
-            Bridging the gap between people, AI and robotics
-          </h2>
-          <div className="top-[3px] absolute left-0 w-full h-px bg-muted" />
-          <div className="top-[2px] absolute left-0 w-[334px] h-[3px] bg-muted" />
-        </div>
-        <div className="grid w-full grid-cols-1 lg:grid-cols-3 gap-12">
-          {features.map((feature) => (
-            <div
-              key={feature.title}
-              className="bg-muted rounded-sm p-6 flex flex-col gap-4"
-            >
-              <img src={feature.icon} alt={feature.title} className="size-16" />
-              <h3 className="text-xl font-medium tracking-tighter text-white">
-                {feature.title}
-              </h3>
-              <p className="text-base font-light tracking-tight text-muted-foreground text-balance">
-                {feature.description}
-              </p>
-            </div>
-          ))}
-        </div>
-        <div className="w-full relative">
-          <div className="top-[3px] absolute left-0 w-full h-px bg-muted" />
-          <div className="top-[2px] absolute right-0 w-[39%] h-[3px] bg-muted" />
         </div>
       </div>
     </div>

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -1,6 +1,7 @@
 import { useFetcher } from "@remix-run/react";
 import { Ratelimit } from "@upstash/ratelimit";
-import { ActionFunctionArgs, json } from "@vercel/remix";
+import type { ActionFunctionArgs } from "@vercel/remix";
+import { json } from "@vercel/remix";
 import { Check } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "~/components/ui/button";
@@ -18,6 +19,20 @@ const ratelimit = new Ratelimit({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
+  if (request.method.toUpperCase() !== "POST") {
+    return json({ ok: true });
+  }
+
+  const formData = await request.formData();
+
+  const honeypots = ["website", "phone", "fax", "title"] as const;
+  for (const field of honeypots) {
+    const value = formData.get(field);
+    if (typeof value === "string" && value.trim().length > 0) {
+      return json({ ok: true });
+    }
+  }
+
   const ip = request.headers.get("x-forwarded-for") ?? "127.0.0.1";
   const { success } = await ratelimit.limit(ip);
 
@@ -28,11 +43,27 @@ export async function action({ request }: ActionFunctionArgs) {
     );
   }
 
-  const formData = await request.formData();
-  const name = String(formData.get("name"));
-  const email = String(formData.get("email"));
-  const company = String(formData.get("companyName"));
-  const message = String(formData.get("message"));
+  const nameEntry = formData.get("name");
+  const emailEntry = formData.get("email");
+  const companyEntry = formData.get("companyName");
+  const messageEntry = formData.get("message");
+
+  if (
+    typeof nameEntry !== "string" ||
+    typeof emailEntry !== "string" ||
+    typeof companyEntry !== "string" ||
+    typeof messageEntry !== "string"
+  ) {
+    return json(
+      { success: false, message: "Invalid form submission" },
+      { status: 400 }
+    );
+  }
+
+  const name = nameEntry.trim();
+  const email = emailEntry.trim();
+  const company = companyEntry.trim();
+  const message = messageEntry.trim();
 
   if (!name || !email || !company || !message) {
     return json(
@@ -70,7 +101,6 @@ export default function Contact() {
   const fetcher = useFetcher<typeof action>();
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isBot, setIsBot] = useState(false);
-  const [intent, setIntent] = useState("Build with us");
   useEffect(() => {
     if (fetcher.data?.success) {
       setIsSubmitted(true);
@@ -120,6 +150,44 @@ export default function Contact() {
             method={isBot ? "get" : "post"}
             className="flex flex-col gap-5"
           >
+            <div className="visually-hidden" aria-hidden="true">
+              <label>
+                Website
+                <input
+                  name="website"
+                  type="text"
+                  tabIndex={-1}
+                  autoComplete="off"
+                />
+              </label>
+              <label>
+                Phone
+                <input
+                  name="phone"
+                  type="text"
+                  tabIndex={-1}
+                  autoComplete="off"
+                />
+              </label>
+              <label>
+                Fax
+                <input
+                  name="fax"
+                  type="text"
+                  tabIndex={-1}
+                  autoComplete="off"
+                />
+              </label>
+              <label>
+                Title
+                <input
+                  name="title"
+                  type="text"
+                  tabIndex={-1}
+                  autoComplete="off"
+                />
+              </label>
+            </div>
             <div className="relative flex flex-col gap-2">
               <Label htmlFor="name">Name</Label>
               <div className="relative flex flex-1">

--- a/app/styles/visually-hidden.css
+++ b/app/styles/visually-hidden.css
@@ -1,0 +1,11 @@
+.visually-hidden {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+  border: 0;
+  padding: 0;
+  margin: -1px;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "www",
       "dependencies": {
+        "@emotion/is-prop-valid": "^1.4.0",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-dialog": "^1.1.10",
         "@radix-ui/react-label": "^2.1.1",
@@ -679,6 +680,21 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
       "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "www",
   "type": "module",
   "dependencies": {
+    "@emotion/is-prop-valid": "^1.4.0",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-dialog": "^1.1.10",
     "@radix-ui/react-label": "^2.1.1",


### PR DESCRIPTION
## Summary
- add a globally available visually hidden utility and load it with the app styles
- expand the contact form with multiple concealed honeypot inputs to trap spam bots
- harden the contact action to short-circuit non-POST requests and silently drop submissions filling honeypot fields while keeping validation intact
- add a shared ESLint configuration and clean up the codebase to satisfy the linter

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d44dbee7b8832ca635e3f6de7e0524