### PR TITLE
Add Playwright CI workflow and expand smoke coverage

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,29 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ api/_assets*
 
 # Generated files
 app/lib/static-blog-data.ts
+test-results/

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -93,6 +93,7 @@ function Plan() {
         {plans.map((item, index) => (
           <div
             key={item.title}
+            data-testid="plan-card"
             className="group w-full bg-accent p-6 border border-border/50 hover:border-muted-foreground flex gap-6 justify-between items-center backdrop-filter backdrop-blur-xl bg-opacity-5 shadow-xl relative text-muted-foreground credit-jhey-animation"
           >
             <div className="flex flex-col flex-grow items-start justify-start gap-2">

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "zod-form-data": "*"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.1",
         "@types/react": "^18.2.74",
         "@types/react-dom": "^18.2.24",
         "@types/tween-functions": "^1.2.2",
@@ -1578,6 +1579,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -15126,6 +15143,53 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.2",
         "pathe": "^1.1.2"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "zod-form-data": "*"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.1",
     "@types/react": "^18.2.74",
     "@types/react-dom": "^18.2.24",
     "@types/tween-functions": "^1.2.2",
@@ -80,7 +81,8 @@
     "dev": "remix vite:dev",
     "lint": "TIMING=1 eslint \"app/**/*.ts*\"",
     "start": "remix-serve ./build/server/index.js",
-    "types": "tsc"
+    "types": "tsc",
+    "test:e2e": "playwright test"
   },
   "sideEffects": false
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = process.env.PLAYWRIGHT_TEST_PORT || "5173";
+const HOST = process.env.PLAYWRIGHT_TEST_HOST || "localhost";
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL || `http://${HOST}:${PORT}`;
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  webServer: {
+    command: `npm run dev -- --port ${PORT} --host ${HOST} --strictPort`,
+    url: baseURL,
+    reuseExistingServer: false,
+    timeout: 120 * 1000,
+    env: {
+      ...process.env,
+      SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN || "test-token",
+      UPSTASH_REDIS_REST_URL:
+        process.env.UPSTASH_REDIS_REST_URL || "https://example.com/redis",
+      UPSTASH_REDIS_REST_TOKEN:
+        process.env.UPSTASH_REDIS_REST_TOKEN || "test-token",
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/tests/coverage-plan.md
+++ b/tests/coverage-plan.md
@@ -1,0 +1,33 @@
+# Playwright End-to-End Test Coverage Plan
+
+This document outlines the initial strategy for using Playwright to cover the
+critical user journeys of the neofactory marketing site. Each milestone builds
+on the previous to incrementally increase confidence while keeping the suite
+fast and maintainable.
+
+## Milestone 1 – Smoke tests (implemented)
+- **Home page renders**: Verify the hero headline "One-person factory" is
+  visible to catch regressions in the landing page shell.
+- **Primary navigation works**: Ensure the "Join Us" call-to-action in the
+  header routes to `/contact` and the contact page headline renders.
+
+## Milestone 2 – Interaction basics
+- [x] **Plan section visibility**: Assert that the "The path to hyper-scale"
+  section is reachable and cards render, confirming scroll-linked content is
+  mounted correctly. Covered by `tests/e2e/home.spec.ts`.
+- [ ] **Footer links**: Validate that external links such as LinkedIn render
+  with the expected `href` attributes.
+
+## Milestone 3 – Contact form validation
+- **Required field validation**: Submit the form without data and confirm the
+  browser reports validation errors. Requires running the test with a seeded
+  `SLACK_BOT_TOKEN` to satisfy server boot requirements.
+- **Successful submission flow**: Post a valid payload while stubbing network
+  calls to Slack, then check for the confirmation message.
+
+## Milestone 4 – Visual confidence (future)
+- Use Playwright's trace viewer and screenshot comparisons for key sections
+  once layout stabilizes.
+
+Each milestone can be toggled via test annotations or tags so CI pipelines can
+choose between a fast smoke suite and deeper regression coverage as needed.

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("marketing site smoke tests", () => {
+  test("home page renders hero headline", async ({ page }) => {
+    await page.goto("/", { waitUntil: "commit" });
+    await expect(
+      page.getByRole("heading", { name: "One-person factory" })
+    ).toBeVisible();
+  });
+
+  test("primary navigation routes to contact page", async ({ page }) => {
+    await page.goto("/", { waitUntil: "commit" });
+    await page
+      .getByRole("banner")
+      .getByRole("link", { name: "Join Us" })
+      .click({ force: true });
+    await expect(page).toHaveURL(/\/contact$/);
+    await expect(
+      page.getByRole("heading", { name: "Build with us" })
+    ).toBeVisible();
+  });
+
+  test("plan section lists the four scaling milestones", async ({ page }) => {
+    await page.goto("/", { waitUntil: "commit" });
+    const planHeading = page.getByRole("heading", {
+      name: "The path to hyper-scale",
+    });
+    await planHeading.waitFor();
+    await planHeading.evaluate((node) =>
+      node.scrollIntoView({ behavior: "instant", block: "center" })
+    );
+    await expect(planHeading).toBeVisible();
+
+    const planCards = page.locator('[data-testid="plan-card"]');
+    await expect(planCards).toHaveCount(4);
+    await expect(
+      planCards
+        .first()
+        .getByRole("heading", { level: 3, name: "Digitized Expertise" })
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- ignore Playwright artifacts and expose a stable selector for home page plan cards
- extend the smoke tests to cover the plan section milestones and document progress in the coverage plan
- add a GitHub Actions workflow that installs browsers and runs the Playwright suite on pushes and pull requests

## Testing
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68d48c3ab028832cb4433c75a88e1ceb