### PR TITLE
Add integration test for Upstash Redis client

### DIFF
--- a/app/lib/upstash.server.test.ts
+++ b/app/lib/upstash.server.test.ts
@@ -1,0 +1,35 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+const hasUpstashEnv =
+  Boolean(process.env.UPSTASH_REDIS_REST_URL) &&
+  Boolean(process.env.UPSTASH_REDIS_REST_TOKEN);
+
+const suite = hasUpstashEnv ? describe : describe.skip;
+
+suite("upstash redis", () => {
+  let redis: Awaited<ReturnType<typeof importRedis>>["redis"];
+
+  async function importRedis() {
+    const mod = await import("~/lib/upstash.server");
+    return mod;
+  }
+
+  beforeAll(async () => {
+    const module = await importRedis();
+    redis = module.redis;
+  });
+
+  it("stores and retrieves values", async () => {
+    const key = `test:upstash:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+    const value = JSON.stringify({ timestamp: Date.now() });
+
+    await redis.set(key, value, { ex: 60 });
+
+    const stored = await redis.get<string>(key);
+    expect(stored).toBe(value);
+
+    await redis.del(key);
+    const removed = await redis.get<string>(key);
+    expect(removed).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add an integration-style Vitest suite that exercises the Upstash Redis client when credentials are available
- guard the suite behind environment checks and dynamically import the client to avoid crashes when the env vars are missing

## Testing
- npm run test:unit -- --run --reporter=dot

------
https://chatgpt.com/codex/tasks/task_e_68d4ba4d68b8832c811a35596e19fde4