### PR TITLE
Update homepage copy placeholders

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -90,13 +90,9 @@ function Plan() {
       />
 
       <div className="max-w-2xl w-full flex flex-col mx-auto mt-12 gap-8 z-50">
-        <h2 className="text-xl lg:text-2xl font-display font-light tracking-wider text-center uppercase">
-          The path to hyper-scale
+        <h2 className="text-[0.9rem] lg:text-[1.08rem] font-display font-light tracking-wider text-center uppercase">
+          A manufacturing model must represent latent physical state and process dynamics, not just imitate what an expert typed or clicked.
         </h2>
-        <p className="text-sm lg:text-base font-normal text-muted-foreground text-center">
-          A manufacturing model must represent latent physical state and process
-          dynamics, not just imitate what an expert typed or clicked.
-        </p>
         {plans.map((item, index) => (
           <div
             key={item.title}
@@ -218,28 +214,21 @@ function Mission() {
           <div className="top-[3px] absolute left-0 w-full h-px bg-accent" />
           <div className="top-[2px] absolute left-0 w-[260px] h-[3px] bg-accent" />
           <h2 className="text-base font-medium tracking-tighter top-[-22px] absolute left-0">
-            Our Mission
+             
           </h2>
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
           <div className="py-20">
             <h2 className="text-3xl lg:text-5xl font-display font-bold tracking-tight text-left uppercase">
-              American abundance through automation
+              {" "}
             </h2>
           </div>
           <div className="flex flex-col w-full mx-auto gap-8 ">
             <p className="text-xl text-balance tracking-tight">
-              We believe that in order to restore American manufacturing
-              dominance, a new approach is needed. Instead of reducing costs
-              with lower wages and government subsidies, we envision a future
-              inspired by our past&ndash; where abundance is created through
-              American ingenuity and automation.
+              {" "}
             </p>
             <p className="text-xl text-balance tracking-tight">
-              AI and robotics are changing the underlying economics of
-              manufacturing. We have a chance to reinvent the American
-              production base, not by longing for the past, but by building the
-              future.
+              {" "}
             </p>
             <div className="flex gap-4">
               <Button size="lg" asChild>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -30,13 +30,16 @@ function Hero() {
       {videoContent}
 
       <div className="max-w-section !my-0 grid-layout z-20 relative gap-4">
-        <h1 className="select-none max-lg:mb-[20px] col-span-full lg:col-span-7 uppercase text-[32px] xs:text-[42px] md:text-[40px] lg:text-[46px] xl:text-[67px] 2xl:text-[80px] leading-heading font-bold text-wrap-balance font-display bg-gradient-to-b from-foreground to-muted-foreground bg-clip-text text-transparent">
-          One-person factory
-        </h1>
-        <div className="col-span-full lg:col-span-5 lg:col-start-8 flex flex-col gap-base lg:mt-[-5.4px]">
-          <h2 className="xs:text-[26px] lg:text-[28px] xl:text-[30px] standard-type-body text-muted-foreground text-wrap-pretty">
-            The orchestration layer for high-mix production lines in critical industries
-          </h2>
+        <div className="col-span-full lg:col-span-10">
+          <p className="max-w-4xl leading-snug text-wrap-pretty">
+            <span className="text-[18px] xs:text-[22px] md:text-[25px] lg:text-[29px] xl:text-[33px] leading-[1.12] font-display font-semibold tracking-tight text-wrap-balance bg-gradient-to-b from-foreground to-muted-foreground bg-clip-text text-transparent">
+              Manufacturing is a uniquely good training ground for physical intelligence.{" "}
+            </span>
+            <span className="text-[20px] xs:text-[22px] md:text-[24px] lg:text-[28px] leading-[1.12] text-muted-foreground">
+              Manufacturing is rare among real-world domains in that it is complex, physical,
+              and yet fully specified.
+            </span>
+          </p>
         </div>
       </div>
     </div>
@@ -45,29 +48,34 @@ function Hero() {
 
 const plans = [
   {
-    title: "Digitized Expertise",
+    title: "Instrumented, closed system",
     icon: "/icons/diamond.svg",
-    shortDescription:
-      "We're using our expertise in precision machining to digitize each step of the manufacturing process to build and operate factories where AI and robotics operate at scale.",
+    shortDescription: "",
+    bulletPoints: [
+      "Manufacturing has complete specifications and hard constraints.",
+      "Processes can be instrumented for rich, objective data collection.",
+      "The environment is closed-loop and finite: every action is testable against ground truth.",
+    ],
   },
   {
-    title: "Virtual Factories",
+    title: "Expertise must be modeled, not observed",
     icon: "/icons/cube.svg",
-    shortDescription:
-      "We've built a software-controlled virtual factory that allows us to simulate and solve end-to-end operations before starting production.",
+    shortDescription: "",
+    bulletPoints: [
+      "Manufacturing processes are dominated by latent variables that sensors don't directly expose.",
+      "Experts function as adaptive controllers, continuously inferring hidden state and adjusting actions under uncertainty.",
+      "What appears as “heuristics” is actually long-horizon belief-state tracking shaped by sparse, delayed physical feedback.",
+    ],
   },
   {
-    title: "On-Site Deployments",
+    title: "High-stakes validation",
     icon: "/icons/triangle.svg",
-    shortDescription:
-      "We'll build our first production line in Dallas, TX in Q3. Further lines will be deployed on site at our partner's facilities.",
-  },
-
-  {
-    title: "Built for Scale",
-    icon: "/icons/chart.svg",
-    shortDescription:
-      "As robotics and AI continue to advance, we'll add more processes, machines, and production lines to our automated operations stack.",
+    shortDescription: "",
+    bulletPoints: [
+      "Manufacturing does not tolerate incorrect internal state.",
+      "Incorrect beliefs surface as measurable defects.",
+      "Only policies with accurate latent-state representations survive.",
+    ],
   },
 ];
 
@@ -86,9 +94,8 @@ function Plan() {
           The path to hyper-scale
         </h2>
         <p className="text-sm lg:text-base font-normal text-muted-foreground text-center">
-          Scaling high-mix low-volume manufacturing requires a new approach to
-          automation. It's not enough to automate the machines. A new layer is
-          needed to automate operations.
+          A manufacturing model must represent latent physical state and process
+          dynamics, not just imitate what an expert typed or clicked.
         </p>
         {plans.map((item, index) => (
           <div
@@ -103,9 +110,17 @@ function Plan() {
                   {item.title}
                 </h3>
               </div>
-              <p className="text-sm font-normal tracking-tight text-muted-foreground">
-                {item.shortDescription}
-              </p>
+              {item.bulletPoints?.length ? (
+                <ul className="list-disc pl-5 text-sm font-normal tracking-tight text-muted-foreground space-y-1">
+                  {item.bulletPoints.map((point) => (
+                    <li key={point}>{point}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm font-normal tracking-tight text-muted-foreground">
+                  {item.shortDescription}
+                </p>
+              )}
             </div>
             <div className="flex flex-col items-end justify-center gap-2">
               <span className="text-xl font-mono font-medium text-white/30 group-hover:text-white">

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -30,16 +30,13 @@ function Hero() {
       {videoContent}
 
       <div className="max-w-section !my-0 grid-layout z-20 relative gap-4">
-        <div className="col-span-full lg:col-span-10">
-          <p className="max-w-4xl leading-snug text-wrap-pretty">
-            <span className="text-[18px] xs:text-[22px] md:text-[25px] lg:text-[29px] xl:text-[33px] leading-[1.12] font-display font-semibold tracking-tight text-wrap-balance bg-gradient-to-b from-foreground to-muted-foreground bg-clip-text text-transparent">
-              Manufacturing is a uniquely good training ground for physical intelligence.{" "}
-            </span>
-            <span className="text-[20px] xs:text-[22px] md:text-[24px] lg:text-[28px] leading-[1.12] text-muted-foreground">
-              Manufacturing is rare among real-world domains in that it is complex, physical,
-              and yet fully specified.
-            </span>
-          </p>
+        <h1 className="select-none max-lg:mb-[20px] col-span-full lg:col-span-7 uppercase text-[32px] xs:text-[42px] md:text-[40px] lg:text-[46px] xl:text-[67px] 2xl:text-[80px] leading-heading font-bold text-wrap-balance font-display bg-gradient-to-b from-foreground to-muted-foreground bg-clip-text text-transparent">
+          One-person factory
+        </h1>
+        <div className="col-span-full lg:col-span-5 lg:col-start-8 flex flex-col gap-base lg:mt-[-5.4px]">
+          <h2 className="xs:text-[26px] lg:text-[28px] xl:text-[30px] standard-type-body text-muted-foreground text-wrap-pretty">
+            The orchestration layer for high-mix production lines in critical industries
+          </h2>
         </div>
       </div>
     </div>
@@ -48,34 +45,29 @@ function Hero() {
 
 const plans = [
   {
-    title: "Instrumented, closed system",
+    title: "Digitized Expertise",
     icon: "/icons/diamond.svg",
-    shortDescription: "",
-    bulletPoints: [
-      "Manufacturing has complete specifications and hard constraints.",
-      "Processes can be instrumented for rich, objective data collection.",
-      "The environment is closed-loop and finite: every action is testable against ground truth.",
-    ],
+    shortDescription:
+      "We're using our expertise in precision machining to digitize each step of the manufacturing process to build and operate factories where AI and robotics operate at scale.",
   },
   {
-    title: "Expertise must be modeled, not observed",
+    title: "Virtual Factories",
     icon: "/icons/cube.svg",
-    shortDescription: "",
-    bulletPoints: [
-      "Manufacturing processes are dominated by latent variables that sensors don't directly expose.",
-      "Experts function as adaptive controllers, continuously inferring hidden state and adjusting actions under uncertainty.",
-      "What appears as “heuristics” is actually long-horizon belief-state tracking shaped by sparse, delayed physical feedback.",
-    ],
+    shortDescription:
+      "We've built a software-controlled virtual factory that allows us to simulate and solve end-to-end operations before starting production.",
   },
   {
-    title: "High-stakes validation",
+    title: "On-Site Deployments",
     icon: "/icons/triangle.svg",
-    shortDescription: "",
-    bulletPoints: [
-      "Manufacturing does not tolerate incorrect internal state.",
-      "Incorrect beliefs surface as measurable defects.",
-      "Only policies with accurate latent-state representations survive.",
-    ],
+    shortDescription:
+      "We'll build our first production line in Dallas, TX in Q3. Further lines will be deployed on site at our partner's facilities.",
+  },
+
+  {
+    title: "Built for Scale",
+    icon: "/icons/chart.svg",
+    shortDescription:
+      "As robotics and AI continue to advance, we'll add more processes, machines, and production lines to our automated operations stack.",
   },
 ];
 
@@ -93,6 +85,11 @@ function Plan() {
         <h2 className="text-[0.9rem] lg:text-[1.08rem] font-display font-light tracking-wider text-center uppercase">
           A manufacturing model must represent latent physical state and process dynamics, not just imitate what an expert typed or clicked.
         </h2>
+        <p className="text-sm lg:text-base font-normal text-muted-foreground text-center">
+          Scaling high-mix low-volume manufacturing requires a new approach to
+          automation. It's not enough to automate the machines. A new layer is
+          needed to automate operations.
+        </p>
         {plans.map((item, index) => (
           <div
             key={item.title}
@@ -106,17 +103,9 @@ function Plan() {
                   {item.title}
                 </h3>
               </div>
-              {item.bulletPoints?.length ? (
-                <ul className="list-disc pl-5 text-sm font-normal tracking-tight text-muted-foreground space-y-1">
-                  {item.bulletPoints.map((point) => (
-                    <li key={point}>{point}</li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="text-sm font-normal tracking-tight text-muted-foreground">
-                  {item.shortDescription}
-                </p>
-              )}
+              <p className="text-sm font-normal tracking-tight text-muted-foreground">
+                {item.shortDescription}
+              </p>
             </div>
             <div className="flex flex-col items-end justify-center gap-2">
               <span className="text-xl font-mono font-medium text-white/30 group-hover:text-white">
@@ -214,7 +203,7 @@ function Mission() {
           <div className="top-[3px] absolute left-0 w-full h-px bg-accent" />
           <div className="top-[2px] absolute left-0 w-[260px] h-[3px] bg-accent" />
           <h2 className="text-base font-medium tracking-tighter top-[-22px] absolute left-0">
-             
+            Our Mission
           </h2>
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -22,16 +22,11 @@ test.describe("marketing site smoke tests", () => {
 
   test("plan section lists the four scaling milestones", async ({ page }) => {
     await page.goto("/", { waitUntil: "commit" });
-    const planHeading = page.getByRole("heading", {
-      name: "The path to hyper-scale",
-    });
-    await planHeading.waitFor();
-    await planHeading.evaluate((node) =>
+    const planCards = page.locator('[data-testid="plan-card"]');
+    await planCards.first().waitFor();
+    await planCards.first().evaluate((node) =>
       node.scrollIntoView({ behavior: "instant", block: "center" })
     );
-    await expect(planHeading).toBeVisible();
-
-    const planCards = page.locator('[data-testid="plan-card"]');
     await expect(planCards).toHaveCount(4);
     await expect(
       planCards


### PR DESCRIPTION
Changes:\n- Update Plan section H2 copy and reduce size by ~10% vs the prior heading.\n- Blank out the Mission headline + body paragraphs with whitespace placeholders for later editing.\n- Adjust Playwright smoke test to avoid asserting the old Plan heading text.\n\nContact page note:\n- Local-only dev changes in app/routes/contact.tsx are not committed and are excluded from this PR.